### PR TITLE
Loosening file validation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,6 @@ test {
 patchPluginXml {
     sinceBuild("171")
     changeNotes """
-      Loosening file validation to allow any file whose name contains `parquet` or `avro`. This means that
+      Loosening file validation to support any file whose name contains `parquet` or `avro`. This means that
       `.parquet.snappy` and `.avro.snappy` files are now supported."""
 }

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group 'uk.co.hadoopathome.intellij.viewer'
-version '1.1.1'
+version '1.1.2'
 
 repositories {
     mavenCentral()
@@ -45,5 +45,6 @@ test {
 patchPluginXml {
     sinceBuild("171")
     changeNotes """
-      Changing Parquet to use AvroParquetReader to reduce Parquet read errors"""
+      Loosening file validation to allow any file whose name contains `parquet` or `avro`. This means that
+      `.parquet.snappy` and `.avro.snappy` files are now supported."""
 }

--- a/src/main/java/uk/co/hadoopathome/intellij/viewer/FileViewerToolWindow.java
+++ b/src/main/java/uk/co/hadoopathome/intellij/viewer/FileViewerToolWindow.java
@@ -171,7 +171,7 @@ public class FileViewerToolWindow implements ToolWindowFactory {
             schemaTextPane.setText(String.format("Processing file %s", file.getPath()));
             try {
               Reader reader =
-                  currentFile.getName().contains("avro")
+                  currentFile.getName().toLowerCase().contains("avro")
                       ? new AvroFileReader(currentFile)
                       : new ParquetFileReader(currentFile);
               List<String> records = reader.getRecords(numRecords);

--- a/src/main/java/uk/co/hadoopathome/intellij/viewer/FileViewerToolWindow.java
+++ b/src/main/java/uk/co/hadoopathome/intellij/viewer/FileViewerToolWindow.java
@@ -89,11 +89,15 @@ public class FileViewerToolWindow implements ToolWindowFactory {
           File file =
               ((List<File>) evt.getTransferable().getTransferData(DataFlavor.javaFileListFlavor))
                   .get(0);
-          String path = file.getPath();
-          if (!path.endsWith(".avro") && !path.endsWith(".parquet")) {
-            JOptionPane.showMessageDialog(null, "Must be a .avro or .parquet file");
+          String fileName = file.getName().toLowerCase();
+          if (!fileName.contains("avro") && !fileName.contains("parquet")) {
+            JOptionPane.showMessageDialog(
+                null,
+                String.format(
+                    "File name \"%s\" must contain either \"avro\" or \"parquet\"", fileName));
             return;
           }
+          String path = file.getPath();
           schemaTextPane.setText(String.format("Processing file %s", path));
           LOGGER.info(String.format("Received file %s", path));
           populatePanes(file, convertComboBoxValueToInt(numRecordsComboBox.getSelectedItem()));
@@ -167,7 +171,7 @@ public class FileViewerToolWindow implements ToolWindowFactory {
             schemaTextPane.setText(String.format("Processing file %s", file.getPath()));
             try {
               Reader reader =
-                  currentFile.getName().endsWith("avro")
+                  currentFile.getName().contains("avro")
                       ? new AvroFileReader(currentFile)
                       : new ParquetFileReader(currentFile);
               List<String> records = reader.getRecords(numRecords);

--- a/src/main/java/uk/co/hadoopathome/intellij/viewer/fileformat/AvroFileReader.java
+++ b/src/main/java/uk/co/hadoopathome/intellij/viewer/fileformat/AvroFileReader.java
@@ -11,6 +11,7 @@ import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.DatumReader;
 
 public class AvroFileReader implements Reader {
+
   private static final Logger LOGGER = Logger.getInstance(AvroFileReader.class);
   private DataFileReader<GenericRecord> dataFileReader;
 

--- a/src/main/java/uk/co/hadoopathome/intellij/viewer/fileformat/LocalInputFile.java
+++ b/src/main/java/uk/co/hadoopathome/intellij/viewer/fileformat/LocalInputFile.java
@@ -16,7 +16,6 @@ import org.apache.parquet.io.SeekableInputStream;
 public class LocalInputFile implements InputFile {
 
   private static final int COPY_BUFFER_SIZE = 8192;
-
   private final RandomAccessFile input;
 
   public LocalInputFile(Path path) throws FileNotFoundException {

--- a/src/main/java/uk/co/hadoopathome/intellij/viewer/fileformat/ParquetFileReader.java
+++ b/src/main/java/uk/co/hadoopathome/intellij/viewer/fileformat/ParquetFileReader.java
@@ -11,6 +11,7 @@ import org.apache.parquet.avro.AvroParquetReader;
 import org.apache.parquet.hadoop.ParquetReader;
 
 public class ParquetFileReader implements Reader {
+
   private static final Logger LOGGER = Logger.getInstance(ParquetFileReader.class);
   private final Path path;
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -2,7 +2,7 @@
     <id>uk.co.hadoopathome.intellij.avro.intellijavroviewer</id>
     <name>Avro and Parquet Viewer</name>
     <description>A Tool Window for viewing Avro and Parquet files and their schemas</description>
-    <version>1.1.1</version>
+    <version>1.1.2</version>
     <vendor email="ben@bwinsights.co.uk" url="http://www.hadoopathome.co.uk">Ben Watson</vendor>
 
     <depends>com.intellij.modules.lang</depends>

--- a/src/test/java/uk/co/hadoopathome/intellij/viewer/fileformat/AvroFileReaderTest.java
+++ b/src/test/java/uk/co/hadoopathome/intellij/viewer/fileformat/AvroFileReaderTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 public class AvroFileReaderTest {
+
   private static final String TWITTER_AVRO_FILE = "avro/twitter.avro";
   // https://github.com/apache/incubator-gobblin/blob/master/gobblin-core/src/test/resources/converter/pickfields_nested_with_union.avro
   private static final String COMPLEX_AVRO_FILE = "avro/pickfields_nested_with_union.avro";


### PR DESCRIPTION
Currently, files must end with either `.avro` or `.parquet`. Whilst fairly safe, this means that perfectly valid `.snappy` files can't be read by the plugin. Following https://github.com/benwatson528/intellij-avro-parquet-plugin/issues/20 I investigated several ways to extract the file type from the file itself:

- `org.apache.tika:tika-core:1.24`
- `net.sf.jmimemagic:jmimemagic:0.1.5`
- `com.j256.simplemagic:simplemagic:1.16`
- `java.nio.file.Files.probeContentType`

but none of these were able to accurately identify both Parquet and Avro files.

In the end, I felt it was better to simply validate that the file name contains either `avro` or `parquet` (case insensitive), and let the plugin's error-handling deal with any issues beyond that.
